### PR TITLE
Give each of the test log artifacts unique names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: test-logs
+          name: test-logs-${{ matrix.os }}
           path: |
             bsc.log
             bsc.sum
@@ -160,7 +160,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: test-logs
+          name: test-logs-${{ matrix.os }}
           path: |
             bsc.log
             bsc.sum


### PR DESCRIPTION
Otherwise they overwrite each other, as artifacts are per build,
not per job.