### PR TITLE
archives_log.sh: Use a more compatible find query

### DIFF
--- a/archive_logs.sh
+++ b/archive_logs.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
-find -E . \
+find . \
     -name bsc.log -o \
     -name bsc.sum -o \
-    -regex '.*\.(diff|bsc|bsc-ccomp|bsc-vcomp|bsc-sched)-out' |
+    -name '*.diff-out' -o \
+    -name '*.bsc-out' -o \
+    -name '*.bsc-ccomp-out' -o \
+    -name '*.bsc-vcomp-out' -o \
+    -name '*.bsc-sched-out' |
     tar zcf logs.tar.gz -T -
 


### PR DESCRIPTION
macOS's (BSD) find doesn't support alternation \(a\|b\)
unless you use -E. (BSD find defaults to 'basic' regular expression,
and -E makes them 'extended basic' regular expressions.)

GNU find defaults to 'extended basic', but doesn't have a -E
flag, instead having a more flexible -regextype parameter.

Avoid this whole morass by just spelling out the different 
filename extensions we want to match. That, at least, is in POSIX.